### PR TITLE
Eliminate dupes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
     "install-and-test": "npm install && npm test --verbose",
     "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short"
   },
+  "standard": {
+    "ignore": [
+      "**/test/"
+    ]
+  },
   "dependencies": {
     "body-parser": "^1.18.3",
     "bootstrap": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
     "install-and-test": "npm install && npm test --verbose",
     "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short"
   },
-  "standard": {
-    "ignore": [
-      "**/test/"
-    ]
-  },
   "dependencies": {
     "body-parser": "^1.18.3",
     "bootstrap": "^4.3.1",

--- a/server/export.js
+++ b/server/export.js
@@ -219,7 +219,7 @@ function getCustomColumnHeaders (customColumns) {
 }
 
 async function exportResults3 (req, res) {
-  req.setTimeout && req.setTimeout(25 * 60 * 1000)
+  req.setTimeout && req.setTimeout(10 * 60 * 1000)
   const correlationId = req.query.correlationId || req.id
   const courseRound = req.query.courseRound
   const fileName = `${courseRound || 'canvas'}-${moment().format('YYYYMMDD-HHMMSS')}-results.csv`

--- a/server/export.js
+++ b/server/export.js
@@ -218,15 +218,6 @@ function getCustomColumnHeaders (customColumns) {
   return _.orderBy(customColumns, ['position'], ['asc']).map(c => c.title)
 }
 
-function findDuplicates (data) {
-  return data.reduce((accumulator, value, index, array) => {
-    if (array.indexOf(value) !== index && accumulator.indexOf(value) < 0) {
-      accumulator.push(value)
-    }
-    return accumulator
-  }, [])
-}
-
 async function exportResults3 (req, res) {
   req.setTimeout && req.setTimeout(25 * 60 * 1000)
   const correlationId = req.query.correlationId || req.id
@@ -340,13 +331,9 @@ async function exportResults3 (req, res) {
     // Instead of writing a status:500, write an error in the file. Otherwise the browser will think that the download is finished.
     res.write('An error occured when exporting. Something is probably missing in this file.')
   }
-  if (findDuplicates(aggregatedData).length) {
-    res.write('"⚠ An error occured and some users are probably missing from this file. We are really sorry for this, and are currently working on solving the cause of the error. Please try again, it should work if you try a second time."')
-    log.warn('Sent an error message to the user.')
-  }
+
   log.info('Finish the response and close ldap client.')
   res.send()
-  log.info(`Number of duplicated found for round ${courseRound} of course ${canvasCourseId}: ${findDuplicates(aggregatedData).length}`)
 }
 
 module.exports = {

--- a/server/submissions.js
+++ b/server/submissions.js
@@ -1,21 +1,54 @@
-async function getSubmissions ({ canvasCourseId, sections, canvasApi }) {
-  const studentsPerSection = sections.map((section) => {
-    if (!section.students) {
-      section.students = []
-    }
-    return section.students.map(student => ({
-      user_id: student.id,
-      section_id: section.id,
-      submissions: [], // Add this to preserve the order of the properties, to make deepEqual possible
-      sis_user_id: student.sis_user_id,
-      integration_id: student.integration_id
-    }))
-  })
+function findDuplicates (submissions) {
+  function generateFindIndexFunction (submissionToFind) {
+    return (element) => element.user_id === submissionToFind.user_id && element.assignment_id === submissionToFind.assignment_id
+  }
 
-  // Flatten the students array
-  const students = [].concat(...studentsPerSection)
+  return submissions.reduce((accumulator, value, index, array) => {
+    const findIndexFunction = generateFindIndexFunction(value)
+    if (array.findIndex(findIndexFunction) !== index && accumulator.findIndex(findIndexFunction)) {
+      accumulator.push(value)
+    }
+    return accumulator
+  }, [])
+}
+
+async function getSubmissions ({ canvasCourseId, sections, canvasApi, log }) {
+  // This code reduces the array of sections containing arrays or students into one student array. It also makes sure each student
+  // only occurs once.
+  const studentsFromSections = sections.reduce((accumulatedSectionStudents, currentSection, currentIndex, sectionsSource) => {
+    if (!currentSection.students) {
+      currentSection.students = []
+    }
+
+    const studentsInSection = currentSection.students.reduce((accumulatedStudents, currentStudent, currentIndex, studentsSource) => {
+      if (!accumulatedStudents.find(student => student.user_id === currentStudent.id)) {
+        let sectionName = currentSection.name
+        const previousStudentEntryIndex = accumulatedSectionStudents.findIndex(sectionStudent => sectionStudent.user_id === currentStudent.id)
+        if (previousStudentEntryIndex > -1) {
+          accumulatedSectionStudents[previousStudentEntryIndex].section_names += ` / ${sectionName}`
+        } else {
+          accumulatedStudents.push({
+            user_id: currentStudent.id,
+            section_names: sectionName,
+            submissions: [], // Add this to preserve the order of the properties, to make deepEqual possible
+            sis_user_id: currentStudent.sis_user_id,
+            integration_id: currentStudent.integration_id
+          })
+        }
+      }
+
+      return accumulatedStudents
+    }, [])
+
+    accumulatedSectionStudents.push(...studentsInSection)
+    return accumulatedSectionStudents
+  }, [])
+
   const submissions = await canvasApi.get(`courses/${canvasCourseId}/students/submissions?student_ids[]=all&order=id&order_direction=ascending&per_page=100`)
-  const studentsWithSubmissions = students.map(student => ({ ...student, submissions: submissions.filter(sub => sub.user_id === student.user_id) }))
+  if (findDuplicates(submissions).length) {
+    log.warn('Found instances of submissions appearing more than once. Could be an indication of something going wrong...')
+  }
+  const studentsWithSubmissions = studentsFromSections.map(student => ({ ...student, submissions: submissions.filter(sub => sub.user_id === student.user_id) }))
 
   return studentsWithSubmissions
 }

--- a/server/submissions.js
+++ b/server/submissions.js
@@ -1,21 +1,7 @@
-function findDuplicates (submissions) {
-  function generateFindIndexFunction (submissionToFind) {
-    return (element) => element.user_id === submissionToFind.user_id && element.assignment_id === submissionToFind.assignment_id
-  }
-
-  return submissions.reduce((accumulator, value, index, array) => {
-    const findIndexFunction = generateFindIndexFunction(value)
-    if (array.findIndex(findIndexFunction) !== index && accumulator.findIndex(findIndexFunction)) {
-      accumulator.push(value)
-    }
-    return accumulator
-  }, [])
-}
-
-async function getSubmissions ({ canvasCourseId, sections, canvasApi, log }) {
-  // This code reduces the array of sections containing arrays or students into one student array. It also makes sure each student
-  // only occurs once.
-  const studentsFromSections = sections.reduce((accumulatedSectionStudents, currentSection, currentIndex, sectionsSource) => {
+// This code reduces the array of sections containing arrays or students into one student array. It also makes sure each student
+// only occurs once.
+function extractStudentsFromSections (sections) {
+  return sections.reduce((accumulatedSectionStudents, currentSection, currentIndex, sectionsSource) => {
     if (!currentSection.students) {
       currentSection.students = []
     }
@@ -23,16 +9,15 @@ async function getSubmissions ({ canvasCourseId, sections, canvasApi, log }) {
     const studentsInSection = currentSection.students.reduce((accumulatedStudents, currentStudent, currentIndex, studentsSource) => {
       if (!accumulatedStudents.find(student => student.user_id === currentStudent.id)) {
         let sectionName = currentSection.name
-        const previousStudentEntryIndex = accumulatedSectionStudents.findIndex(sectionStudent => sectionStudent.user_id === currentStudent.id)
-        if (previousStudentEntryIndex > -1) {
-          accumulatedSectionStudents[previousStudentEntryIndex].section_names += ` / ${sectionName}`
+        const previousStudentEntry = accumulatedSectionStudents.find(sectionStudent => sectionStudent.user_id === currentStudent.id)
+        if (previousStudentEntry) {
+          previousStudentEntry.section_names += ` / ${sectionName}`
         } else {
           accumulatedStudents.push({
             user_id: currentStudent.id,
             section_names: sectionName,
             submissions: [], // Add this to preserve the order of the properties, to make deepEqual possible
-            sis_user_id: currentStudent.sis_user_id,
-            integration_id: currentStudent.integration_id
+            sis_user_id: currentStudent.sis_user_id
           })
         }
       }
@@ -43,11 +28,11 @@ async function getSubmissions ({ canvasCourseId, sections, canvasApi, log }) {
     accumulatedSectionStudents.push(...studentsInSection)
     return accumulatedSectionStudents
   }, [])
+}
 
+async function getSubmissions ({ canvasCourseId, sections, canvasApi, log }) {
+  const studentsFromSections = extractStudentsFromSections(sections)
   const submissions = await canvasApi.get(`courses/${canvasCourseId}/students/submissions?student_ids[]=all&order=id&order_direction=ascending&per_page=100`)
-  if (findDuplicates(submissions).length) {
-    log.warn('Found instances of submissions appearing more than once. Could be an indication of something going wrong...')
-  }
   const studentsWithSubmissions = studentsFromSections.map(student => ({ ...student, submissions: submissions.filter(sub => sub.user_id === student.user_id) }))
 
   return studentsWithSubmissions

--- a/server/submissions.js
+++ b/server/submissions.js
@@ -1,6 +1,4 @@
-// This code reduces the array of sections containing arrays or students into one student array. It also makes sure each student
-// only occurs once.
-function extractStudentsFromSections (sections) {
+function extractUniqueStudentsAndSectionNamesFromSections (sections) {
   return sections.reduce((accumulatedSectionStudents, currentSection, currentIndex, sectionsSource) => {
     if (!currentSection.students) {
       currentSection.students = []
@@ -31,7 +29,7 @@ function extractStudentsFromSections (sections) {
 }
 
 async function getSubmissions ({ canvasCourseId, sections, canvasApi, log }) {
-  const studentsFromSections = extractStudentsFromSections(sections)
+  const studentsFromSections = extractUniqueStudentsAndSectionNamesFromSections(sections)
   const submissions = await canvasApi.get(`courses/${canvasCourseId}/students/submissions?student_ids[]=all&order=id&order_direction=ascending&per_page=100`)
   const studentsWithSubmissions = studentsFromSections.map(student => ({ ...student, submissions: submissions.filter(sub => sub.user_id === student.user_id) }))
 

--- a/test/integration/specs/index.js
+++ b/test/integration/specs/index.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-require('dotenv').config({path: 'test/.env'})
+require('dotenv').config({ path: 'test/.env' })
 const randomstring = require('randomstring')
 
 const webdriver = require('selenium-webdriver')
@@ -26,9 +26,9 @@ rimraf(folderName)
 let options = new firefox.Options().setProfile(profile)
 
 const driver = new webdriver.Builder()
-    .forBrowser('firefox')
-    .setFirefoxOptions(options)
-    .build()
+  .forBrowser('firefox')
+  .setFirefoxOptions(options)
+  .build()
 
 async function createCanvasCourse () {
   const courseCode = 'A' + randomstring.generate(5)
@@ -39,18 +39,18 @@ async function createCanvasCourse () {
   }
 
   const accountId = 14 // Courses that starts with an 'A' is handled by account 14
-  const canvasCourse = await canvasApi.createCourse({course}, accountId)
+  const canvasCourse = await canvasApi.createCourse({ course }, accountId)
   await canvasApi.createDefaultSection(canvasCourse)
   return canvasCourse
 }
 
-async function prepareCourse(course){
+async function prepareCourse (course) {
   // Enroll the test user, 56313, as a teacher
   // Enroll some students
   return result
 }
 
-async function setupCourse(){
+async function setupCourse () {
   return await prepareCourse(await createCanvasCourse())
 }
 
@@ -68,7 +68,7 @@ test(`should write a file
     // TODO: should set the timeout to somethinge shorter, since we want it to timeout. But preferably sooner.
     await driver.findElement(By.css('input[type="submit"]')).click()
   } catch (e) {
-    console.log('timeout. This is good, now check file content...', )
+    console.log('timeout. This is good, now check file content...')
   }
 
   fs.readdirSync(folderName).forEach(file => {

--- a/test/integration/specs/submissions/index.test.js
+++ b/test/integration/specs/submissions/index.test.js
@@ -5,26 +5,24 @@ require('dotenv').config()
 const canvasApiUrl = `https://${process.env.CANVAS_HOST}/api/v1`
 
 const canvasApi = new CanvasApi(canvasApiUrl, process.env.CANVAS_TOKEN)
-const {getSubmissions} = require('../../../../server/submissions')
+const { getSubmissions } = require('../../../../server/submissions')
 
 // TODO: this isn't really a good integration test, I just used it during the development. I guess we should remove it.
 test('should construct the similar json', async t => {
-    const sections = await canvasApi.get(`courses/3719/sections?include[]=students`)
+  const sections = await canvasApi.get(`courses/3719/sections?include[]=students`)
 
-    // Get the json, sorted, without the test user. The new function don't incluce the test users.
-    const oldWay = (await canvasApi.get(`courses/3719/students/submissions?grouped=1&student_ids[]=all&per_page=100`)).sort((a, b) => a.user_id - b.user_id).filter(stud => stud.user_id !== 55842)
+  // Get the json, sorted, without the test user. The new function don't incluce the test users.
+  const oldWay = (await canvasApi.get(`courses/3719/students/submissions?grouped=1&student_ids[]=all&per_page=100`)).sort((a, b) => a.user_id - b.user_id).filter(stud => stud.user_id !== 55842)
 
-    const students = (await getSubmissions(3719, sections))
-    // Make sure both arrays are sorted, so I can compare them
-    const newWay = students.sort((a, b) => a.user_id - b.user_id)
+  const students = (await getSubmissions(3719, sections))
+  // Make sure both arrays are sorted, so I can compare them
+  const newWay = students.sort((a, b) => a.user_id - b.user_id)
 
-    // Ignore seconds late when comparing, since these are changed for every api call
-    oldWay.forEach(student => student.submissions.forEach(sub => delete sub.seconds_late))
-    newWay.forEach(student => student.submissions.forEach(sub => delete sub.seconds_late))
+  // Ignore seconds late when comparing, since these are changed for every api call
+  oldWay.forEach(student => student.submissions.forEach(sub => delete sub.seconds_late))
+  newWay.forEach(student => student.submissions.forEach(sub => delete sub.seconds_late))
 
-    assert.deepEqual(oldWay, newWay)
+  assert.deepEqual(oldWay, newWay)
 
-    t.end()
+  t.end()
 })
-
-

--- a/test/specs/ResultsTable.getHeaders.test.js
+++ b/test/specs/ResultsTable.getHeaders.test.js
@@ -13,7 +13,7 @@ ResultsTable.__set__('rp', () => ({
 }))
 
 test('"getHeaders()" should not work if "preload()" is not called before', async t => {
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   try {
     file.getHeaders()
@@ -30,7 +30,7 @@ test('"getHeaders()" should return 7 fixed headers when preload()-ed data is emp
     }
   })
 
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
   const expectedHeaders = [
@@ -54,7 +54,7 @@ test('"getHeaders()" should return 9 headers when data is one assignment (7 fixe
   class FakeCanvasApi {
     get (url) {
       if (url.includes('assignments')) {
-        return [{id: ASSIGNMENT_ID, name: ASSIGNMENT_NAME}]
+        return [{ id: ASSIGNMENT_ID, name: ASSIGNMENT_NAME }]
       } else {
         return []
       }
@@ -62,7 +62,7 @@ test('"getHeaders()" should return 9 headers when data is one assignment (7 fixe
   }
 
   ResultsTable.__set__('CanvasApi', FakeCanvasApi)
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
 
@@ -82,10 +82,10 @@ test('"getHeaders()" should return 9 headers when data is one assignment (7 fixe
 
 test('"getHeaders()" returns 15 headers when data are four assignment (7 fixed + 2 per assignment)', async t => {
   const assignments = [
-    {id: 'a1', name: 'a1name'},
-    {id: 'a2', name: 'a2name'},
-    {id: 'a3', name: 'a3name'},
-    {id: 'a4', name: 'a4name'},
+    { id: 'a1', name: 'a1name' },
+    { id: 'a2', name: 'a2name' },
+    { id: 'a3', name: 'a3name' },
+    { id: 'a4', name: 'a4name' }
   ]
   // A CanvasApi that returns always empty arrays
   class FakeCanvasApi {
@@ -99,7 +99,7 @@ test('"getHeaders()" returns 15 headers when data are four assignment (7 fixed +
   }
 
   ResultsTable.__set__('CanvasApi', FakeCanvasApi)
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
 
@@ -109,7 +109,7 @@ test('"getHeaders()" returns 15 headers when data are four assignment (7 fixed +
 
   assignments.forEach((a, index) => {
     t.ok(headers[7 + index * 2].includes(a.id), `header ${7 + index * 2} should contain the ID of the assignment`)
-    t.ok(headers[7 + index * 2 + 1].includes(a.id),   `header ${7 + index * 2 + 1} should contain the ID of the assignment`)
+    t.ok(headers[7 + index * 2 + 1].includes(a.id), `header ${7 + index * 2 + 1} should contain the ID of the assignment`)
   })
 
   assignments.forEach((a, index) => {
@@ -119,9 +119,9 @@ test('"getHeaders()" returns 15 headers when data are four assignment (7 fixed +
 
   headers.slice(7).forEach((header, i) => {
     if (i % 2 === 0) {
-      t.ok(header.includes('submission date'), `header ${i+7} should contain "submission date"`)
+      t.ok(header.includes('submission date'), `header ${i + 7} should contain "submission date"`)
     } else {
-      t.ok(header.includes('grade'), `header ${i+7} should contain "grade"`)
+      t.ok(header.includes('grade'), `header ${i + 7} should contain "grade"`)
     }
   })
 
@@ -132,9 +132,9 @@ test('"getHeaders() returns 10 headers when data are 1 assignment + 1 custom col
   class FakeCanvasApi {
     get (url) {
       if (url.includes('assignments')) {
-        return [{id: 'a1', name: 'a1name'}]
+        return [{ id: 'a1', name: 'a1name' }]
       } else if (url.includes('custom_gradebook_columns') && !url.includes('data')) {
-        return [{position: 0, title: 'custom column 1'}]
+        return [{ position: 0, title: 'custom column 1' }]
       } else {
         return []
       }
@@ -142,7 +142,7 @@ test('"getHeaders() returns 10 headers when data are 1 assignment + 1 custom col
   }
 
   ResultsTable.__set__('CanvasApi', FakeCanvasApi)
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
 
@@ -158,9 +158,9 @@ test('"getHeaders() returns custom columns sorted by "position" in Canvas', asyn
     get (url) {
       if (url.includes('custom_gradebook_columns') && !url.includes('data')) {
         return [
-          {position: 2, title: 'custom column 2'},
-          {position: 0, title: 'custom column 0'},
-          {position: 1, title: 'custom column 1'}
+          { position: 2, title: 'custom column 2' },
+          { position: 0, title: 'custom column 0' },
+          { position: 1, title: 'custom column 1' }
         ]
       } else {
         return []
@@ -169,7 +169,7 @@ test('"getHeaders() returns custom columns sorted by "position" in Canvas', asyn
   }
 
   ResultsTable.__set__('CanvasApi', FakeCanvasApi)
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
 

--- a/test/specs/ResultsTable.iterateLines.test.js
+++ b/test/specs/ResultsTable.iterateLines.test.js
@@ -26,7 +26,7 @@ test('"iterateLines()" with 0 students should finish without calling the callbac
   ResultsTable.__set__('ldap.getBoundClient', () => ldapClientMock)
   ResultsTable.__set__('CanvasApi', CanvasApiMock)
 
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.iterateRows(() => {
     t.fail('the callback was called')
@@ -48,7 +48,7 @@ test('"iterateLines()" with 1 student should throw an error if preload() was not
         }
       } else if (url.includes('students/submissions')) {
         await cb([
-          {id: '1'}
+          { id: '1' }
         ])
       } else {
         return []
@@ -59,7 +59,7 @@ test('"iterateLines()" with 1 student should throw an error if preload() was not
   ResultsTable.__set__('ldap.getBoundClient', () => ldapClientMock)
   ResultsTable.__set__('CanvasApi', CanvasApiMock)
 
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   try {
     await file.iterateRows(() => {
@@ -74,7 +74,7 @@ test('"iterateLines()" with 1 student should throw an error if preload() was not
 
 test('"iterateLines()" should work normally', async t => {
   const ldapMock = {
-    getBoundClient() {
+    getBoundClient () {
       return {
         unbind: () => {}
       }
@@ -94,22 +94,22 @@ test('"iterateLines()" should work normally', async t => {
     async get (url, cb) {
       if (url.includes('courses/canvas_course_id/assignments')) {
         return [
-          {name: 'Assignment 1', id: 'a1'},
-          {name: 'Assignment 2', id: 'a2'}
+          { name: 'Assignment 1', id: 'a1' },
+          { name: 'Assignment 2', id: 'a2' }
         ]
       } else if (url.includes('courses/canvas_course_id/users?enrollment_type[]=student_view')) {
         return []
       } else if (url.includes('courses/canvas_course_id/users?enrollment_type[]=student')) {
         return [
-          {name: 'John', id: 'u1', login_id: 'john@example.com'}
+          { name: 'John', id: 'u1', login_id: 'john@example.com' }
         ]
       } else if (url.includes('courses/canvas_course_id/custom_gradebook_columns/cc1/data')) {
         return [
-          {user_id: 'u1', content: 'CC content'}
+          { user_id: 'u1', content: 'CC content' }
         ]
       } else if (url.includes('courses/canvas_course_id/custom_gradebook_columns')) {
         return [
-          {title: 'CC 1', id: 'cc1', position: 0}
+          { title: 'CC 1', id: 'cc1', position: 0 }
         ]
       } else if (url.includes('courses/canvas_course_id/students/submissions')) {
         return cb([{
@@ -117,8 +117,8 @@ test('"iterateLines()" should work normally', async t => {
           sis_user_id: 'sis1',
           section_id: 'section1',
           submissions: [
-            {assignment_id: 'a1', submitted_at: 'SUBMISSION-1', entered_grade: 'pass1'},
-            {assignment_id: 'a2', submitted_at: 'SUBMISSION-2', entered_grade: 'pass2'}
+            { assignment_id: 'a1', submitted_at: 'SUBMISSION-1', entered_grade: 'pass1' },
+            { assignment_id: 'a2', submitted_at: 'SUBMISSION-2', entered_grade: 'pass2' }
           ]
         }])
       }
@@ -126,7 +126,7 @@ test('"iterateLines()" should work normally', async t => {
 
     async requestUrl (url) {
       if (url.includes('sections/section1')) {
-        return {name: 'Section 1'}
+        return { name: 'Section 1' }
       }
     }
   }
@@ -134,7 +134,7 @@ test('"iterateLines()" should work normally', async t => {
   ResultsTable.__set__('ldap', ldapMock)
   ResultsTable.__set__('CanvasApi', CanvasApiMock)
 
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
 
@@ -152,7 +152,7 @@ test('"iterateLines()" should work normally', async t => {
 
 test('"iterateLines()" should work even if some fields are missing', async t => {
   const ldapMock = {
-    getBoundClient() {
+    getBoundClient () {
       return {
         unbind: () => {}
       }
@@ -164,21 +164,21 @@ test('"iterateLines()" should work even if some fields are missing', async t => 
     async get (url, cb) {
       if (url.includes('courses/canvas_course_id/assignments')) {
         return [
-          {name: 'Assignment 1', id: 'a1'},
+          { name: 'Assignment 1', id: 'a1' }
         ]
       } else if (url.includes('courses/canvas_course_id/users?enrollment_type[]=student_view')) {
         return []
       } else if (url.includes('courses/canvas_course_id/users?enrollment_type[]=student')) {
         return [
-          {name: 'John', id: 'u1', login_id: 'john@example.com'}
+          { name: 'John', id: 'u1', login_id: 'john@example.com' }
         ]
       } else if (url.includes('courses/canvas_course_id/custom_gradebook_columns/cc1/data')) {
         return [
-          {user_id: 'u1', content: 'CC content'}
+          { user_id: 'u1', content: 'CC content' }
         ]
       } else if (url.includes('courses/canvas_course_id/custom_gradebook_columns')) {
         return [
-          {title: 'CC 1', id: 'cc1', position: 0}
+          { title: 'CC 1', id: 'cc1', position: 0 }
         ]
       } else if (url.includes('courses/canvas_course_id/students/submissions')) {
         return cb([{
@@ -200,7 +200,7 @@ test('"iterateLines()" should work even if some fields are missing', async t => 
   ResultsTable.__set__('ldap', ldapMock)
   ResultsTable.__set__('CanvasApi', CanvasApiMock)
 
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
 
@@ -217,7 +217,7 @@ test('"iterateLines()" should work even if some fields are missing', async t => 
 
 test('returned assignments should be in the right order', async t => {
   const ldapMock = {
-    getBoundClient() {
+    getBoundClient () {
       return {
         unbind: () => {}
       }
@@ -243,15 +243,15 @@ test('returned assignments should be in the right order', async t => {
     async get (url, cb) {
       if (url.includes('courses/canvas_course_id/assignments')) {
         return [
-          {name: 'Assignment 1', id: 'a1'},
-          {name: 'Assignment 2', id: 'a2'}
+          { name: 'Assignment 1', id: 'a1' },
+          { name: 'Assignment 2', id: 'a2' }
         ]
       } else if (url.includes('courses/canvas_course_id/users?enrollment_type[]=student_view')) {
         return []
       } else if (url.includes('courses/canvas_course_id/users?enrollment_type[]=student')) {
         return [
-          {name: 'John', id: 'u1', login_id: 'john@example.com'},
-          {name: 'Anna', id: 'u2', login_id: 'anna@example.com'}
+          { name: 'John', id: 'u1', login_id: 'john@example.com' },
+          { name: 'Anna', id: 'u2', login_id: 'anna@example.com' }
         ]
       } else if (url.includes('courses/canvas_course_id/custom_gradebook_columns/cc1/data')) {
         return []
@@ -264,7 +264,7 @@ test('returned assignments should be in the right order', async t => {
             sis_user_id: 'sis1',
             section_id: 'section1',
             submissions: [
-              {assignment_id: 'a2', submitted_at: 'SUBMISSION-1-2', entered_grade: 'pass1-2'}
+              { assignment_id: 'a2', submitted_at: 'SUBMISSION-1-2', entered_grade: 'pass1-2' }
             ]
           },
           {
@@ -272,8 +272,8 @@ test('returned assignments should be in the right order', async t => {
             sis_user_id: 'sis2',
             section_id: 'section1',
             submissions: [
-              {assignment_id: 'a1', submitted_at: 'SUBMISSION-2-1', entered_grade: 'pass2-1'},
-              {assignment_id: 'a2', submitted_at: 'SUBMISSION-2-2', entered_grade: 'pass2-2'}
+              { assignment_id: 'a1', submitted_at: 'SUBMISSION-2-1', entered_grade: 'pass2-1' },
+              { assignment_id: 'a2', submitted_at: 'SUBMISSION-2-2', entered_grade: 'pass2-2' }
             ]
           }
         ])
@@ -282,7 +282,7 @@ test('returned assignments should be in the right order', async t => {
 
     async requestUrl (url) {
       if (url.includes('sections/section1')) {
-        return {name: 'Section 1'}
+        return { name: 'Section 1' }
       }
     }
   }
@@ -290,7 +290,7 @@ test('returned assignments should be in the right order', async t => {
   ResultsTable.__set__('ldap', ldapMock)
   ResultsTable.__set__('CanvasApi', CanvasApiMock)
 
-  const file = await ResultsTable.create('canvas_course_id', {log, oauth: {}})
+  const file = await ResultsTable.create('canvas_course_id', { log, oauth: {} })
 
   await file.preload()
   const body = []

--- a/test/specs/export.assignments.test.js
+++ b/test/specs/export.assignments.test.js
@@ -9,7 +9,7 @@ const createSubmissionLineContent = _export.__get__('createSubmissionLineContent
  * Return a canvasApi instance with a mocked "get" function
  */
 const setupCanvasApi = (canvasCourseId, assignments) => {
-  const canvasApi = {get: sinon.stub()}
+  const canvasApi = { get: sinon.stub() }
 
   canvasApi
     .get.withArgs(`/courses/${canvasCourseId}/assignments`)
@@ -24,7 +24,7 @@ test('should get assignment ids and headers', async t => {
     { id: 0, name: 'Assignment 1' }
   ])
 
-  const result = await getAssignmentIdsAndHeaders({canvasApi, canvasCourseId})
+  const result = await getAssignmentIdsAndHeaders({ canvasApi, canvasCourseId })
 
   const expected = {
     assignmentIds: ['0'],
@@ -41,7 +41,7 @@ test('should return empty arrays if there are no assignments', async t => {
   const canvasCourseId = 0
   const canvasApi = setupCanvasApi(canvasCourseId, [])
 
-  const result = await getAssignmentIdsAndHeaders({canvasApi, canvasCourseId})
+  const result = await getAssignmentIdsAndHeaders({ canvasApi, canvasCourseId })
 
   const expected = {
     assignmentIds: [],
@@ -52,14 +52,13 @@ test('should return empty arrays if there are no assignments', async t => {
   t.end()
 })
 
-
 test('should return an empty array if no submissions', async t => {
   const student = {
     submissions: []
   }
   const assignmentIds = []
 
-  const result = createSubmissionLineContent({student, assignmentIds})
+  const result = createSubmissionLineContent({ student, assignmentIds })
   const expected = []
 
   t.deepEqual(result, expected)
@@ -69,17 +68,16 @@ test('should return an empty array if no submissions', async t => {
 test('should return string results even for non-existent data', t => {
   const student = {
     submissions: [
-      {assignment_id: 0},
-      {assignment_id: 15, entered_grade: 'L'},
-      {assignment_id: 16, entered_grade: 'O'},
-      {assignment_id: 23, entered_grade: 'S'},
-      {assignment_id: 42, entered_grade: 'T'},
+      { assignment_id: 0 },
+      { assignment_id: 15, entered_grade: 'L' },
+      { assignment_id: 16, entered_grade: 'O' },
+      { assignment_id: 23, entered_grade: 'S' },
+      { assignment_id: 42, entered_grade: 'T' }
     ]
   }
   const assignmentIds = [4, 8, 15, 16, 23, 42]
 
-
-  const result = createSubmissionLineContent({student, assignmentIds})
+  const result = createSubmissionLineContent({ student, assignmentIds })
 
   t.equal(result.length, 12)
 
@@ -89,7 +87,6 @@ test('should return string results even for non-existent data', t => {
 
   t.end()
 })
-
 
 test('createSubmission 2x elements as getAssignmentIds', async t => {
   const canvasCourseId = 0
@@ -106,8 +103,8 @@ test('createSubmission 2x elements as getAssignmentIds', async t => {
     submissions: []
   }
 
-  const {assignmentIds, headers} = await getAssignmentIdsAndHeaders({canvasApi, canvasCourseId})
-  const result = createSubmissionLineContent({student, assignmentIds})
+  const { assignmentIds, headers } = await getAssignmentIdsAndHeaders({ canvasApi, canvasCourseId })
+  const result = createSubmissionLineContent({ student, assignmentIds })
 
   t.ok(
     Object.keys(headers).length * 2 === result.length,

--- a/test/specs/export.custom-columns.test.js
+++ b/test/specs/export.custom-columns.test.js
@@ -8,7 +8,7 @@ const getCustomColumnsFn = _export.__get__('getCustomColumnsFn')
 test('should return a function with user_id as argument, and the column data as return value', async t => {
   const userId = 123456
   const canvasCourseId = 0
-  const canvasApi = {get: sinon.stub()}
+  const canvasApi = { get: sinon.stub() }
   const canvasApiUrl = ''
   const columnId = 1
   const columnId2 = 2
@@ -49,7 +49,7 @@ test('should return a function with user_id as argument, and the column data as 
     ]
   )
 
-  const {getCustomColumnsData} = await getCustomColumnsFn({canvasApi, canvasCourseId, canvasApiUrl})
+  const { getCustomColumnsData } = await getCustomColumnsFn({ canvasApi, canvasCourseId, canvasApiUrl })
   const result = getCustomColumnsData(userId)
   const expected = {
     [columnId]: 'en anteckning...',
@@ -83,7 +83,7 @@ test(`should sort the custom column headers by position`, t => {
 test(`should return an array with the custom columns data,
   or empty string if no data exists,
   sorted by custom columns position`, t => {
-  const customColumnsData = {184: 'en anteckning...'}
+  const customColumnsData = { 184: 'en anteckning...' }
   const customColumns = [
     {
       id: 185,
@@ -99,7 +99,7 @@ test(`should return an array with the custom columns data,
       hidden: false
     }]
   const createCustomColumnsContent = _export.__get__('createCustomColumnsContent')
-  const result = createCustomColumnsContent({customColumns, customColumnsData})
+  const result = createCustomColumnsContent({ customColumns, customColumnsData })
   t.deepEqual(result, ['en anteckning...', ''])
   t.end()
 })
@@ -108,9 +108,9 @@ test(`should return a function with user_id as argument,
   and an object as result
   if the user has no data for the custom columns
   `, async t => {
-  const userId = 123, userId2 = 456
+  const userId = 123; const userId2 = 456
   const canvasCourseId = 0
-  const canvasApi = {get: sinon.stub()}
+  const canvasApi = { get: sinon.stub() }
   const canvasApiUrl = ''
   const columnId = 1
 
@@ -130,7 +130,7 @@ test(`should return a function with user_id as argument,
     []
   )
 
-  const {getCustomColumnsData} = await getCustomColumnsFn({canvasApi, canvasCourseId, canvasApiUrl})
+  const { getCustomColumnsData } = await getCustomColumnsFn({ canvasApi, canvasCourseId, canvasApiUrl })
   const result = getCustomColumnsData(userId2)
   const expected = {}
   t.deepEqual(result, expected)

--- a/test/specs/export.test.js
+++ b/test/specs/export.test.js
@@ -15,7 +15,7 @@ _export.__set__('ldap', {
   getBoundClient () {
     console.log('mocking ldap client')
     return {
-      unbind(){}
+      unbind () {}
     }
   }
 })
@@ -24,8 +24,8 @@ const exportResults = _export.__get__('exportResults')
 const exportResults3 = _export.__get__('exportResults3')
 
 test('should redirect to the Canvas authentication page', t => {
-  const res = {redirect: sinon.spy()}
-  const req = {body: {}, get: () => ''}
+  const res = { redirect: sinon.spy() }
+  const req = { body: {}, get: () => '' }
 
   exportResults(req, res)
 
@@ -34,12 +34,13 @@ test('should redirect to the Canvas authentication page', t => {
 })
 
 test('should send status:500 if exportResults breaks', t => {
-  const res = {status: sinon.stub().returns({
+  const res = { status: sinon.stub().returns({
     send () {}
-  })}
-  const req = {body: {}, get: () => {
-    throw new Error('Just pretending that something breaks...')
-  }}
+  }) }
+  const req = { body: {},
+    get: () => {
+      throw new Error('Just pretending that something breaks...')
+    } }
 
   exportResults(req, res)
 
@@ -57,7 +58,7 @@ test(`should write a file
     write: sinon.spy(),
     send () {}
   }
-  const req = {query: {courseRound: 'round', canvasCourseId: 'canvasCourseId'}, get: () => ''}
+  const req = { query: { courseRound: 'round', canvasCourseId: 'canvasCourseId' }, get: () => '' }
 
   _export.__set__('getAccessToken', () => 'mocked token')
   await exportResults3(req, res)

--- a/test/specs/submissions.test.js
+++ b/test/specs/submissions.test.js
@@ -1,0 +1,161 @@
+const test = require('tape')
+const rewire = require('rewire')
+const _export = rewire('../../server/submissions')
+
+const extractStudentsFromSections = _export.__get__('extractStudentsFromSections')
+const userA = {
+  id: 2,
+  sis_user_id: 'SHEL93921',
+  sis_import_id: 16
+}
+const userB = {
+  id: 4,
+  sis_user_id: 'SHEL93922',
+  sis_import_id: 4
+}
+const userC = {
+  id: 8,
+  sis_user_id: 'SHEL93923',
+  sis_import_id: 1
+}
+const userD = {
+  id: 16,
+  sis_user_id: 'SHEL93924',
+  sis_import_id: 3
+}
+const userE = {
+  id: 32,
+  sis_user_id: 'SHEL93925',
+  sis_import_id: 9
+}
+const emptySectionTemplateA = {
+  name: 'Section A',
+  students: null
+}
+const emptySectionTemplateB = {
+  name: 'Section B',
+  students: null
+}
+const sectionTemplateA = {
+  name: 'Section C',
+  students: [userA, userB]
+}
+const sectionTemplateB = {
+  name: 'Section D',
+  students: [userC, userD, userE]
+}
+
+const emptySections1 = []
+const emptySectionsResult1 = []
+const emptySections2 = [
+  {
+    name: 'Section A',
+    students: null
+  }, {
+    name: 'Section B',
+    students: null
+  }
+]
+const emptySectionsResult2 = []
+
+const uniqueSections = [
+  {
+    name: 'Section C',
+    students: [
+      {
+        id: 2,
+        sis_user_id: 'SHEL93921'
+      },
+      {
+        id: 4,
+        sis_user_id: 'SHEL93922'
+      }
+    ]
+  }, {
+    name: 'Section D',
+    students: [
+      {
+        id: 8,
+        sis_user_id: 'SHEL93923'
+      },
+      {
+        id: 16,
+        sis_user_id: 'SHEL93924'
+      },
+      {
+        id: 32,
+        sis_user_id: 'SHEL93925'
+      }
+    ]
+  }
+]
+const uniqueSectionsResult = [
+  {
+    user_id: 2,
+    section_names: 'Section C',
+    submissions: [],
+    sis_user_id: 'SHEL93921'
+  },
+  {
+    user_id: 4,
+    section_names: 'Section C',
+    submissions: [],
+    sis_user_id: 'SHEL93922'
+  },
+  {
+    user_id: 8,
+    section_names: 'Section D',
+    submissions: [],
+    sis_user_id: 'SHEL93923'
+  },
+  {
+    user_id: 16,
+    section_names: 'Section D',
+    submissions: [],
+    sis_user_id: 'SHEL93924'
+  },
+  {
+    user_id: 32,
+    section_names: 'Section D',
+    submissions: [],
+    sis_user_id: 'SHEL93925'
+  }
+]
+
+const duplicateSections1 = uniqueSections.slice()
+duplicateSections1[1].students.push(
+  {
+    id: 8,
+    sis_user_id: 'SHEL93923'
+  }
+)
+const duplicateSectionsResult1 = uniqueSectionsResult
+
+const duplicateSections2 = uniqueSections.slice()
+duplicateSections1[1].students.push(
+  {
+    id: 4,
+    sis_user_id: 'SHEL93922'
+  }
+)
+const duplicateSectionsResult2 = uniqueSectionsResult.slice()
+duplicateSectionsResult2[1].section_names = 'Section C / Section D'
+
+test('should correctly extract unique students from list of sections', t => {
+  let extractedStudents = extractStudentsFromSections(emptySections1)
+  t.deepEqual(extractedStudents, emptySectionsResult1, 'function should be able to handle empty sections')
+
+  extractedStudents = extractStudentsFromSections(emptySections2)
+  t.deepEqual(extractedStudents, emptySectionsResult2, 'function should be able to handle sections without students')
+
+  extractedStudents = extractStudentsFromSections(uniqueSections)
+  t.deepEqual(extractedStudents, uniqueSectionsResult, 'function should be able to handle all unique students')
+
+  extractedStudents = extractStudentsFromSections(duplicateSections1)
+  t.deepEqual(extractedStudents, duplicateSectionsResult1, 'function should be able to handle duplicated students found within the same section')
+
+  extractedStudents = extractStudentsFromSections(duplicateSections2)
+  t.deepEqual(extractedStudents, duplicateSectionsResult2, 'function should be able to handle duplicated students found across different sections')
+
+  t.end()
+})

--- a/test/specs/submissions.test.js
+++ b/test/specs/submissions.test.js
@@ -2,48 +2,7 @@ const test = require('tape')
 const rewire = require('rewire')
 const _export = rewire('../../server/submissions')
 
-const extractStudentsFromSections = _export.__get__('extractStudentsFromSections')
-const userA = {
-  id: 2,
-  sis_user_id: 'SHEL93921',
-  sis_import_id: 16
-}
-const userB = {
-  id: 4,
-  sis_user_id: 'SHEL93922',
-  sis_import_id: 4
-}
-const userC = {
-  id: 8,
-  sis_user_id: 'SHEL93923',
-  sis_import_id: 1
-}
-const userD = {
-  id: 16,
-  sis_user_id: 'SHEL93924',
-  sis_import_id: 3
-}
-const userE = {
-  id: 32,
-  sis_user_id: 'SHEL93925',
-  sis_import_id: 9
-}
-const emptySectionTemplateA = {
-  name: 'Section A',
-  students: null
-}
-const emptySectionTemplateB = {
-  name: 'Section B',
-  students: null
-}
-const sectionTemplateA = {
-  name: 'Section C',
-  students: [userA, userB]
-}
-const sectionTemplateB = {
-  name: 'Section D',
-  students: [userC, userD, userE]
-}
+const extractStudentsFromSections = _export.__get__('extractUniqueStudentsAndSectionNamesFromSections')
 
 const emptySections1 = []
 const emptySectionsResult1 = []


### PR DESCRIPTION
So, this is a new version which intends to achieve the following:

- Make sure we only have one instance of each student when we extract a list of them from the sections. We make sure to concatenate a string of all section names the student was found in.
- Added code to try to detect if a submission appears twice when fetching all. My theory is that their uniqueness is defined by the user-id/assignment-id combo.
- Removed the old duplicate check, since it should never trigger with the aforementioned changes.